### PR TITLE
CPU Architecture option

### DIFF
--- a/fedora-coreos/kubernetes/variables.tf
+++ b/fedora-coreos/kubernetes/variables.tf
@@ -30,27 +30,29 @@ variable "os_version" {
 
 variable "controllers" {
   type = list(object({
-    name   = string
-    mac    = string
-    domain = string
+    name             = string
+    mac              = string
+    domain           = string
+    cpu_architecture = optional(string, "x86_64")
   }))
   description = <<EOD
 List of controller machine details (unique name, identifying MAC address, FQDN)
-[{ name = "node1", mac = "52:54:00:a1:9c:ae", domain = "node1.example.com"}]
+[{ name = "node1", mac = "52:54:00:a1:9c:ae", domain = "node1.example.com", cpu_architecture="x86_64"}]
 EOD
 }
 
 variable "workers" {
   type = list(object({
-    name   = string
-    mac    = string
-    domain = string
+    name             = string
+    mac              = string
+    domain           = string
+    cpu_architecture = optional(string, "x86_64")
   }))
   description = <<EOD
 List of worker machine details (unique name, identifying MAC address, FQDN)
 [
-  { name = "node2", mac = "52:54:00:b2:2f:86", domain = "node2.example.com"},
-  { name = "node3", mac = "52:54:00:c3:61:77", domain = "node3.example.com"}
+  { name = "node2", mac = "52:54:00:b2:2f:86", domain = "node2.example.com", cpu_architecture="x86_64"},
+  { name = "node3", mac = "52:54:00:c3:61:77", domain = "node3.example.com", cpu_architecture="aarch64"}
 ]
 EOD
   default     = []

--- a/fedora-coreos/kubernetes/worker/matchbox.tf
+++ b/fedora-coreos/kubernetes/worker/matchbox.tf
@@ -1,24 +1,24 @@
 locals {
-  remote_kernel = "https://builds.coreos.fedoraproject.org/prod/streams/${var.os_stream}/builds/${var.os_version}/x86_64/fedora-coreos-${var.os_version}-live-kernel-x86_64"
+  remote_kernel = "https://builds.coreos.fedoraproject.org/prod/streams/${var.os_stream}/builds/${var.os_version}/${var.cpu_architecture}/fedora-coreos-${var.os_version}-live-kernel-${var.cpu_architecture}"
   remote_initrd = [
-    "--name main https://builds.coreos.fedoraproject.org/prod/streams/${var.os_stream}/builds/${var.os_version}/x86_64/fedora-coreos-${var.os_version}-live-initramfs.x86_64.img",
+    "--name main https://builds.coreos.fedoraproject.org/prod/streams/${var.os_stream}/builds/${var.os_version}/${var.cpu_architecture}/fedora-coreos-${var.os_version}-live-initramfs.${var.cpu_architecture}.img",
   ]
 
   remote_args = [
     "initrd=main",
-    "coreos.live.rootfs_url=https://builds.coreos.fedoraproject.org/prod/streams/${var.os_stream}/builds/${var.os_version}/x86_64/fedora-coreos-${var.os_version}-live-rootfs.x86_64.img",
+    "coreos.live.rootfs_url=https://builds.coreos.fedoraproject.org/prod/streams/${var.os_stream}/builds/${var.os_version}/${var.cpu_architecture}/fedora-coreos-${var.os_version}-live-rootfs.${var.cpu_architecture}.img",
     "coreos.inst.install_dev=${var.install_disk}",
     "coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
   ]
 
-  cached_kernel = "/assets/fedora-coreos/fedora-coreos-${var.os_version}-live-kernel-x86_64"
+  cached_kernel = "/assets/fedora-coreos/fedora-coreos-${var.os_version}-live-kernel-${var.cpu_architecture}"
   cached_initrd = [
-    "/assets/fedora-coreos/fedora-coreos-${var.os_version}-live-initramfs.x86_64.img",
+    "/assets/fedora-coreos/fedora-coreos-${var.os_version}-live-initramfs.${var.cpu_architecture}.img",
   ]
 
   cached_args = [
     "initrd=main",
-    "coreos.live.rootfs_url=${var.matchbox_http_endpoint}/assets/fedora-coreos/fedora-coreos-${var.os_version}-live-rootfs.x86_64.img",
+    "coreos.live.rootfs_url=${var.matchbox_http_endpoint}/assets/fedora-coreos/fedora-coreos-${var.os_version}-live-rootfs.${var.cpu_architecture}.img",
     "coreos.inst.install_dev=${var.install_disk}",
     "coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
   ]

--- a/fedora-coreos/kubernetes/worker/variables.tf
+++ b/fedora-coreos/kubernetes/worker/variables.tf
@@ -73,6 +73,12 @@ variable "node_taints" {
   default     = []
 }
 
+variable "cpu_architecture" {
+  type        = string
+  description = "CPU architecture (x86_64, arm64, s390x...) needed"
+  default     = "x86_64"
+}
+
 # optional
 
 variable "cached_install" {

--- a/fedora-coreos/kubernetes/workers.tf
+++ b/fedora-coreos/kubernetes/workers.tf
@@ -10,9 +10,10 @@ module "workers" {
   os_version             = var.os_version
 
   # machine
-  name   = var.workers[count.index].name
-  mac    = var.workers[count.index].mac
-  domain = var.workers[count.index].domain
+  name             = var.workers[count.index].name
+  mac              = var.workers[count.index].mac
+  domain           = var.workers[count.index].domain
+  cpu_architecture = var.workers[count.index].cpu_architecture
 
   # configuration
   kubeconfig            = module.bootstrap.kubeconfig-kubelet

--- a/flatcar-linux/kubernetes/butane/install.yaml
+++ b/flatcar-linux/kubernetes/butane/install.yaml
@@ -35,6 +35,7 @@ storage:
             -d ${install_disk} \
             -C ${os_channel} \
             -V ${os_version} \
+            -B ${cpu_architecture}-usr \
             -o "${oem_type}" \
             ${baseurl_flag} \
             -i ignition.json

--- a/flatcar-linux/kubernetes/variables.tf
+++ b/flatcar-linux/kubernetes/variables.tf
@@ -29,27 +29,30 @@ variable "os_version" {
 
 variable "controllers" {
   type = list(object({
-    name   = string
-    mac    = string
-    domain = string
+    name             = string
+    mac              = string
+    domain           = string
+    cpu_architecture = optional(string, "x86_64")
   }))
   description = <<EOD
 List of controller machine details (unique name, identifying MAC address, FQDN)
-[{ name = "node1", mac = "52:54:00:a1:9c:ae", domain = "node1.example.com"}]
+[{ name = "node1", mac = "52:54:00:a1:9c:ae", domain = "node1.example.com"}, arch="x86_64"]
 EOD
+  default     = []
 }
 
 variable "workers" {
   type = list(object({
-    name   = string
-    mac    = string
-    domain = string
+    name             = string
+    mac              = string
+    domain           = string
+    cpu_architecture = optional(string, "x86_64")
   }))
   description = <<EOD
 List of worker machine details (unique name, identifying MAC address, FQDN)
 [
-  { name = "node2", mac = "52:54:00:b2:2f:86", domain = "node2.example.com"},
-  { name = "node3", mac = "52:54:00:c3:61:77", domain = "node3.example.com"}
+  { name = "node2", mac = "52:54:00:b2:2f:86", domain = "node2.example.com", arch="x86_64"},
+  { name = "node3", mac = "52:54:00:c3:61:77", domain = "node3.example.com", arch="aarch64"}
 ]
 EOD
   default     = []

--- a/flatcar-linux/kubernetes/worker/butane/install.yaml
+++ b/flatcar-linux/kubernetes/worker/butane/install.yaml
@@ -35,6 +35,7 @@ storage:
             -d ${install_disk} \
             -C ${os_channel} \
             -V ${os_version} \
+            -B ${cpu_architecture}-usr \
             -o "${oem_type}" \
             ${baseurl_flag} \
             -i ignition.json

--- a/flatcar-linux/kubernetes/worker/matchbox.tf
+++ b/flatcar-linux/kubernetes/worker/matchbox.tf
@@ -1,10 +1,11 @@
 locals {
   # flatcar-stable -> stable channel
-  channel = split("-", var.os_channel)[1]
+  channel          = split("-", var.os_channel)[1]
+  cpu_architecture = (var.cpu_architecture == "x86_64") ? "amd64" : "arm64"
 
-  remote_kernel = "${var.download_protocol}://${local.channel}.release.flatcar-linux.net/amd64-usr/${var.os_version}/flatcar_production_pxe.vmlinuz"
+  remote_kernel = "${var.download_protocol}://${local.channel}.release.flatcar-linux.net/${local.cpu_architecture}-usr/${var.os_version}/flatcar_production_pxe.vmlinuz"
   remote_initrd = [
-    "${var.download_protocol}://${local.channel}.release.flatcar-linux.net/amd64-usr/${var.os_version}/flatcar_production_pxe_image.cpio.gz",
+    "${var.download_protocol}://${local.channel}.release.flatcar-linux.net/${local.cpu_architecture}-usr/${var.os_version}/flatcar_production_pxe_image.cpio.gz",
   ]
   args = flatten([
     "initrd=flatcar_production_pxe_image.cpio.gz",
@@ -13,9 +14,9 @@ locals {
     var.kernel_args,
   ])
 
-  cached_kernel = "/assets/flatcar/${var.os_version}/flatcar_production_pxe.vmlinuz"
+  cached_kernel = "/assets/flatcar/${local.cpu_architecture}/${var.os_version}/flatcar_production_pxe.vmlinuz"
   cached_initrd = [
-    "/assets/flatcar/${var.os_version}/flatcar_production_pxe_image.cpio.gz",
+    "/assets/flatcar/${local.cpu_architecture}/${var.os_version}/flatcar_production_pxe_image.cpio.gz",
   ]
 
   kernel = var.cached_install ? local.cached_kernel : local.remote_kernel
@@ -46,6 +47,7 @@ data "ct_config" "install" {
   content = templatefile("${path.module}/butane/install.yaml", {
     os_channel         = local.channel
     os_version         = var.os_version
+    cpu_architecture   = local.cpu_architecture
     ignition_endpoint  = format("%s/ignition", var.matchbox_http_endpoint)
     mac                = var.mac
     install_disk       = var.install_disk

--- a/flatcar-linux/kubernetes/worker/variables.tf
+++ b/flatcar-linux/kubernetes/worker/variables.tf
@@ -42,6 +42,11 @@ variable "domain" {
   description = "Fully qualified domain name (e.g. node1.example.com)"
 }
 
+variable "cpu_architecture" {
+  type        = string
+  description = ""
+}
+
 # configuration
 
 variable "kubeconfig" {

--- a/flatcar-linux/kubernetes/workers.tf
+++ b/flatcar-linux/kubernetes/workers.tf
@@ -10,9 +10,10 @@ module "workers" {
   os_version             = var.os_version
 
   # machine
-  name   = var.workers[count.index].name
-  mac    = var.workers[count.index].mac
-  domain = var.workers[count.index].domain
+  name             = var.workers[count.index].name
+  mac              = var.workers[count.index].mac
+  domain           = var.workers[count.index].domain
+  cpu_architecture = var.workers[count.index].cpu_architecture
 
   # configuration
   kubeconfig            = module.bootstrap.kubeconfig-kubelet


### PR DESCRIPTION
Typhoon on flatcar could previously only be run on x86_64 nodes.
This commit changes this by adding a new variable per node which is
cpu_architecture.

This value is set by default on "x86_64".
This variable is used for caching, selecting the architecture when
installing flatcar, and grabbing the right files with the remote
kernel and remote initrd.
This value can be set when defining a node at the same time
as other attributes such a machine's  domain, mac address or
name.

This PR concerns both Flatcar Linux and Fedora CoreOS

Tested successfully on the test suite with x86_64 VMs. 
I haven't tried with aarch64 VMs and mixed VMs (some aarch64, some x86_64) yet since I don't have KVM enabled for `qemu-system-aarch64` (looks like I only have access to the `tcg` accelerator there) and thus can't use terraform's libvirt since it requires KVM.