### PR TITLE
Added optional variable for machine identification

### DIFF
--- a/fedora-coreos/kubernetes/variables.tf
+++ b/fedora-coreos/kubernetes/variables.tf
@@ -30,27 +30,29 @@ variable "os_version" {
 
 variable "controllers" {
   type = list(object({
-    name   = string
-    mac    = string
-    domain = string
+    name            = string
+    mac             = string
+    domain          = string
+    extra_selectors = optional(map(string), {})
   }))
   description = <<EOD
-List of controller machine details (unique name, identifying MAC address, FQDN)
-[{ name = "node1", mac = "52:54:00:a1:9c:ae", domain = "node1.example.com"}]
+List of controller machine details (unique name, identifying MAC address, FQDN and other fields used to identify this machine)
+[{ name = "node1", mac = "52:54:00:a1:9c:ae", domain = "node1.example.com", {"uuid":"123e4567-e89b-12d3-a456-426614174000"}}]
 EOD
 }
 
 variable "workers" {
   type = list(object({
-    name   = string
-    mac    = string
-    domain = string
+    name            = string
+    mac             = string
+    domain          = string
+    extra_selectors = optional(map(string), {})
   }))
   description = <<EOD
-List of worker machine details (unique name, identifying MAC address, FQDN)
+  List of worker machine details (unique name, identifying MAC address, FQDN and other fields used to identify this machine)
 [
-  { name = "node2", mac = "52:54:00:b2:2f:86", domain = "node2.example.com"},
-  { name = "node3", mac = "52:54:00:c3:61:77", domain = "node3.example.com"}
+  { name = "node2", mac = "52:54:00:b2:2f:86", domain = "node2.example.com", {"uuid":"123e4567-e89b-12d3-a456-426614174001"}},
+  { name = "node3", mac = "52:54:00:c3:61:77", domain = "node3.example.com", {"uuid":"123e4567-e89b-12d3-a456-426614174002"}}
 ]
 EOD
   default     = []
@@ -149,6 +151,12 @@ variable "enable_aggregation" {
   type        = bool
   description = "Enable the Kubernetes Aggregation Layer"
   default     = true
+}
+
+variable "extra_selectors" {
+  type        = map(string)
+  description = "Additional identifying fields"
+  default     = {}
 }
 
 # unofficial, undocumented, unsupported

--- a/fedora-coreos/kubernetes/worker/matchbox.tf
+++ b/fedora-coreos/kubernetes/worker/matchbox.tf
@@ -8,7 +8,7 @@ locals {
     "initrd=main",
     "coreos.live.rootfs_url=https://builds.coreos.fedoraproject.org/prod/streams/${var.os_stream}/builds/${var.os_version}/x86_64/fedora-coreos-${var.os_version}-live-rootfs.x86_64.img",
     "coreos.inst.install_dev=${var.install_disk}",
-    "coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
+    "coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?$${extra_selectors}mac=$${mac:hexhyp}",
   ]
 
   cached_kernel = "/assets/fedora-coreos/fedora-coreos-${var.os_version}-live-kernel-x86_64"
@@ -20,7 +20,7 @@ locals {
     "initrd=main",
     "coreos.live.rootfs_url=${var.matchbox_http_endpoint}/assets/fedora-coreos/fedora-coreos-${var.os_version}-live-rootfs.x86_64.img",
     "coreos.inst.install_dev=${var.install_disk}",
-    "coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
+    "coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?$${extra_selectors}mac=$${mac:hexhyp}",
   ]
 
   kernel = var.cached_install ? local.cached_kernel : local.remote_kernel
@@ -33,7 +33,8 @@ resource "matchbox_group" "worker" {
   name    = format("%s-%s", var.cluster_name, var.name)
   profile = matchbox_profile.worker.name
   selector = {
-    mac = var.mac
+    mac             = var.mac
+    extra_selectors = var.extra_selectors
   }
 }
 

--- a/fedora-coreos/kubernetes/worker/variables.tf
+++ b/fedora-coreos/kubernetes/worker/variables.tf
@@ -93,6 +93,12 @@ variable "kernel_args" {
   default     = []
 }
 
+variable "extra_selectors" {
+  type        = map(string)
+  description = "Additional identifying fields"
+  default     = {}
+}
+
 # unofficial, undocumented, unsupported
 
 variable "service_cidr" {

--- a/fedora-coreos/kubernetes/workers.tf
+++ b/fedora-coreos/kubernetes/workers.tf
@@ -10,9 +10,10 @@ module "workers" {
   os_version             = var.os_version
 
   # machine
-  name   = var.workers[count.index].name
-  mac    = var.workers[count.index].mac
-  domain = var.workers[count.index].domain
+  name            = var.workers[count.index].name
+  mac             = var.workers[count.index].mac
+  domain          = var.workers[count.index].domain
+  extra_selectors = (length(var.workers[count.index].extra_selectors) > 0) ? join("", [for key, value in var.workers[count.index].extra_selectors : "${urlencode(key)}=${urlencode(value)}&"]) : ""
 
   # configuration
   kubeconfig            = module.bootstrap.kubeconfig-kubelet

--- a/flatcar-linux/kubernetes/butane/install.yaml
+++ b/flatcar-linux/kubernetes/butane/install.yaml
@@ -30,7 +30,7 @@ storage:
       contents:
         inline: |
           #!/bin/bash -ex
-          curl --retry 10 "${ignition_endpoint}?mac=${mac}&os=installed" -o ignition.json
+          curl --retry 10 "${ignition_endpoint}?${extra_selectors}mac=${mac}&os=installed" -o ignition.json
           flatcar-install \
             -d ${install_disk} \
             -C ${os_channel} \

--- a/flatcar-linux/kubernetes/variables.tf
+++ b/flatcar-linux/kubernetes/variables.tf
@@ -29,27 +29,29 @@ variable "os_version" {
 
 variable "controllers" {
   type = list(object({
-    name   = string
-    mac    = string
-    domain = string
+    name            = string
+    mac             = string
+    domain          = string
+    extra_selectors = optional(map(string), {})
   }))
   description = <<EOD
-List of controller machine details (unique name, identifying MAC address, FQDN)
-[{ name = "node1", mac = "52:54:00:a1:9c:ae", domain = "node1.example.com"}]
+List of controller machine details (unique name, identifying MAC address, FQDN, other fields used to identify the machine)
+[{ name = "node1", mac = "52:54:00:a1:9c:ae", domain = "node1.example.com", {"uuid":"123e4567-e89b-12d3-a456-426614174000"}}]
 EOD
 }
 
 variable "workers" {
   type = list(object({
-    name   = string
-    mac    = string
-    domain = string
+    name            = string
+    mac             = string
+    domain          = string
+    extra_selectors = optional(map(string), {})
   }))
   description = <<EOD
 List of worker machine details (unique name, identifying MAC address, FQDN)
 [
-  { name = "node2", mac = "52:54:00:b2:2f:86", domain = "node2.example.com"},
-  { name = "node3", mac = "52:54:00:c3:61:77", domain = "node3.example.com"}
+  { name = "node2", mac = "52:54:00:b2:2f:86", domain = "node2.example.com", {"uuid":"123e4567-e89b-12d3-a456-426614174001"}},
+  { name = "node3", mac = "52:54:00:c3:61:77", domain = "node3.example.com", {"uuid":"123e4567-e89b-12d3-a456-426614174002"}}
 ]
 EOD
   default     = []
@@ -165,6 +167,12 @@ E.g., `flatcar_production_vmware_raw_image.bin.bz2` leads to `vmware_raw`.
 See: https://www.flatcar.org/docs/latest/installing/bare-metal/installing-to-disk/#choose-a-channel
 EOD
   default     = ""
+}
+
+variable "extra_selectors" {
+  type        = map(string)
+  description = "Additional identifying fields"
+  default     = {}
 }
 
 # unofficial, undocumented, unsupported

--- a/flatcar-linux/kubernetes/worker/butane/install.yaml
+++ b/flatcar-linux/kubernetes/worker/butane/install.yaml
@@ -30,7 +30,7 @@ storage:
       contents:
         inline: |
           #!/bin/bash -ex
-          curl --retry 10 "${ignition_endpoint}?mac=${mac}&os=installed" -o ignition.json
+          curl --retry 10 "${ignition_endpoint}?${extra_selectors}mac=${mac}&os=installed" -o ignition.json
           flatcar-install \
             -d ${install_disk} \
             -C ${os_channel} \

--- a/flatcar-linux/kubernetes/worker/matchbox.tf
+++ b/flatcar-linux/kubernetes/worker/matchbox.tf
@@ -8,7 +8,7 @@ locals {
   ]
   args = flatten([
     "initrd=flatcar_production_pxe_image.cpio.gz",
-    "flatcar.config.url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
+    "flatcar.config.url=${var.matchbox_http_endpoint}/ignition?$${extra_selectors}mac=$${mac:hexhyp}",
     "flatcar.first_boot=yes",
     var.kernel_args,
   ])
@@ -22,7 +22,7 @@ locals {
   initrd = var.cached_install ? local.cached_initrd : local.remote_initrd
 }
 
-# Match machine to an install profile by MAC
+# Match machine to an install profile by MAC and extra selectors if there are any
 resource "matchbox_group" "install" {
   name    = format("install-%s", var.name)
   profile = matchbox_profile.install.name
@@ -48,6 +48,7 @@ data "ct_config" "install" {
     os_version         = var.os_version
     ignition_endpoint  = format("%s/ignition", var.matchbox_http_endpoint)
     mac                = var.mac
+    extra_selectors    = var.extra_selectors
     install_disk       = var.install_disk
     ssh_authorized_key = var.ssh_authorized_key
     oem_type           = var.oem_type
@@ -62,8 +63,9 @@ resource "matchbox_group" "worker" {
   name    = format("%s-%s", var.cluster_name, var.name)
   profile = matchbox_profile.worker.name
   selector = {
-    mac = var.mac
-    os  = "installed"
+    mac             = var.mac
+    extra_selectors = var.extra_selectors
+    os              = "installed"
   }
 }
 

--- a/flatcar-linux/kubernetes/worker/variables.tf
+++ b/flatcar-linux/kubernetes/worker/variables.tf
@@ -104,6 +104,12 @@ variable "oem_type" {
   description = "An OEM type to install with flatcar-install."
 }
 
+variable "extra_selectors" {
+  type        = string
+  description = "Additional identifying fields"
+  default     = ""
+}
+
 # unofficial, undocumented, unsupported
 
 variable "service_cidr" {

--- a/flatcar-linux/kubernetes/workers.tf
+++ b/flatcar-linux/kubernetes/workers.tf
@@ -10,8 +10,9 @@ module "workers" {
   os_version             = var.os_version
 
   # machine
-  name   = var.workers[count.index].name
-  mac    = var.workers[count.index].mac
+  name            = var.workers[count.index].name
+  mac             = var.workers[count.index].mac
+  extra_selectors = (length(var.workers[count.index].extra_selectors) > 0) ? join("", [for key, value in var.workers[count.index].extra_selectors : "${urlencode(key)}=${urlencode(value)}&"]) : ""
   domain = var.workers[count.index].domain
 
   # configuration


### PR DESCRIPTION
This PR adds alternative selectors other than just the MAC of a machine through the use of generic selectors in the form of a map(string).
This allows one to use other fields like the UUID of a machine to identify it in the curl done with the update.
This PR concerns both Fedora CoreOS and flatcar-linux.