### PR TITLE
Changing the way the install_disk is set

### DIFF
--- a/fedora-coreos/kubernetes/profiles.tf
+++ b/fedora-coreos/kubernetes/profiles.tf
@@ -7,7 +7,6 @@ locals {
   remote_args = [
     "initrd=main",
     "coreos.live.rootfs_url=https://builds.coreos.fedoraproject.org/prod/streams/${var.os_stream}/builds/${var.os_version}/x86_64/fedora-coreos-${var.os_version}-live-rootfs.x86_64.img",
-    "coreos.inst.install_dev=${var.install_disk}",
     "coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
   ]
 
@@ -19,7 +18,6 @@ locals {
   cached_args = [
     "initrd=main",
     "coreos.live.rootfs_url=${var.matchbox_http_endpoint}/assets/fedora-coreos/fedora-coreos-${var.os_version}-live-rootfs.x86_64.img",
-    "coreos.inst.install_dev=${var.install_disk}",
     "coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
   ]
 
@@ -46,7 +44,11 @@ resource "matchbox_profile" "controllers" {
 
   kernel = local.kernel
   initrd = local.initrd
-  args   = concat(local.args, var.kernel_args)
+  args = concat(
+    local.args,
+    var.kernel_args,
+    "coreos.inst.install_dev=${var.controllers.*.install_disk[count.index]}"
+  )
 
   raw_ignition = data.ct_config.controllers.*.rendered[count.index]
 }

--- a/fedora-coreos/kubernetes/variables.tf
+++ b/fedora-coreos/kubernetes/variables.tf
@@ -30,9 +30,10 @@ variable "os_version" {
 
 variable "controllers" {
   type = list(object({
-    name   = string
-    mac    = string
-    domain = string
+    name         = string
+    mac          = string
+    domain       = string
+    install_disk = optional(string, "sda")
   }))
   description = <<EOD
 List of controller machine details (unique name, identifying MAC address, FQDN)
@@ -42,9 +43,10 @@ EOD
 
 variable "workers" {
   type = list(object({
-    name   = string
-    mac    = string
-    domain = string
+    name         = string
+    mac          = string
+    domain       = string
+    install_disk = optional(string, "sda")
   }))
   description = <<EOD
 List of worker machine details (unique name, identifying MAC address, FQDN)
@@ -125,12 +127,6 @@ variable "cached_install" {
   type        = bool
   description = "Whether Fedora CoreOS should PXE boot and install from matchbox /assets cache. Note that the admin must have downloaded the os_version into matchbox assets."
   default     = false
-}
-
-variable "install_disk" {
-  type        = string
-  description = "Disk device to install Fedora CoreOS (e.g. sda)"
-  default     = "sda"
 }
 
 variable "kernel_args" {

--- a/fedora-coreos/kubernetes/workers.tf
+++ b/fedora-coreos/kubernetes/workers.tf
@@ -25,6 +25,6 @@ module "workers" {
 
   # optional
   cached_install = var.cached_install
-  install_disk   = var.install_disk
+  install_disk   = var.workers[count.index].install_disk
   kernel_args    = var.kernel_args
 }

--- a/flatcar-linux/kubernetes/profiles.tf
+++ b/flatcar-linux/kubernetes/profiles.tf
@@ -53,7 +53,7 @@ data "ct_config" "install" {
     os_version         = var.os_version
     ignition_endpoint  = format("%s/ignition", var.matchbox_http_endpoint)
     mac                = concat(var.controllers.*.mac, var.workers.*.mac)[count.index]
-    install_disk       = var.install_disk
+    install_disk       = var.controllers[count.index].install_disk
     ssh_authorized_key = var.ssh_authorized_key
     oem_type           = var.oem_type
     # only cached profile adds -b baseurl

--- a/flatcar-linux/kubernetes/variables.tf
+++ b/flatcar-linux/kubernetes/variables.tf
@@ -29,9 +29,10 @@ variable "os_version" {
 
 variable "controllers" {
   type = list(object({
-    name   = string
-    mac    = string
-    domain = string
+    name         = string
+    mac          = string
+    domain       = string
+    install_disk = optional(string, "/dev/sda")
   }))
   description = <<EOD
 List of controller machine details (unique name, identifying MAC address, FQDN)
@@ -41,9 +42,10 @@ EOD
 
 variable "workers" {
   type = list(object({
-    name   = string
-    mac    = string
-    domain = string
+    name         = string
+    mac          = string
+    domain       = string
+    install_disk = optional(string, "/dev/sda")
   }))
   description = <<EOD
 List of worker machine details (unique name, identifying MAC address, FQDN)
@@ -130,12 +132,6 @@ variable "cached_install" {
   type        = bool
   description = "Whether Flatcar Linux should PXE boot and install from matchbox /assets cache. Note that the admin must have downloaded the os_version into matchbox assets."
   default     = false
-}
-
-variable "install_disk" {
-  type        = string
-  default     = "/dev/sda"
-  description = "Disk device to which the install profiles should install Flatcar Linux (e.g. /dev/sda)"
 }
 
 variable "kernel_args" {

--- a/flatcar-linux/kubernetes/workers.tf
+++ b/flatcar-linux/kubernetes/workers.tf
@@ -26,7 +26,7 @@ module "workers" {
   # optional
   download_protocol = var.download_protocol
   cached_install    = var.cached_install
-  install_disk      = var.install_disk
+  install_disk      = var.workers[count.index].install_disk
   kernel_args       = var.kernel_args
   oem_type          = var.oem_type
 }


### PR DESCRIPTION
Formerly, the install_disk variable would affect all the machines configured with Typhoon. This meant that we could only set disks such as /dev/sda or /dev/nvme0n1 and that we could not use paths such as /dev/disk/by-* because those are associated to a single specific machine.
This commit aims to change this by giving an install_disk attribute to controller and worker objects.
This change affects both the FCOS and Flatcar Container Linux sides of things.

This PR has been tested with the test-suite available on the `test-suite` branch.